### PR TITLE
check for unhashable names and fall back to their name in the module …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import shlex
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
 import codecs
+import os
+
 from setuptools import setup
 
 
@@ -13,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-involve",
-    version="0.1.2",
+    version="0.1.3",
     author="Tom Keefe",
     author_email="tomlkeefe@gmail.com",
     maintainer="Tom Keefe",


### PR DESCRIPTION
…if specified. This is pretty niche, but I have seen it happen with mock objects.